### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   repository-manager:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Ze0ro99/PlMetaConnect/security/code-scanning/1](https://github.com/Ze0ro99/PlMetaConnect/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the required permissions. Based on the workflow's operations, it primarily interacts with the repository contents (e.g., checking out the code) and deploys to Vercel using a token. Therefore, the minimal permissions required are `contents: read` for accessing the repository and no additional write permissions. This ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
